### PR TITLE
COGHENT-51: Add indexes to Member schema

### DIFF
--- a/lib/models/Member.js
+++ b/lib/models/Member.js
@@ -28,6 +28,18 @@ const attributes = {
         defaultValue: '{}'
     },
 };
+const indexes = [
+    {
+        fields: ['institution']
+    },
+    {
+        fields: ['adlibDatabase']
+    },
+    {
+        fields: ['generatedAtTime']
+    },
+];
 
 module.exports.Member = Member;
 module.exports.attributes = attributes;
+module.exports.indexes = indexes;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,7 +34,8 @@ module.exports = new class Utils {
             // Other model options go here
             sequelize, // We need to pass the connection instance
             modelName: 'Member', // We need to choose the model name,
-            createdAt: 'generatedAtTime' // I want createdAt to be called generatedAtTime
+            createdAt: 'generatedAtTime', // I want createdAt to be called generatedAtTime
+            indexes: require('./models/Member').indexes
         };
         await Member.init(memberAttributes, memberOptions);
         //await sequelize.sync({force: true});


### PR DESCRIPTION
Columns that are used in where/sort clauses may require an index:

```
    let generatedAtTimes = await this._db.models.Member.findAll({
        where: {
            institution: institution,
            adlibDatabase: adlibDatabase
        },
        order: [
            ['generatedAtTime', 'DESC']
        ]
    });
```

cf https://sequelize.org/master/manual/indexes.html