### PR TITLE
Fix array

### DIFF
--- a/src/lib/mappers/utils.js
+++ b/src/lib/mappers/utils.js
@@ -807,7 +807,7 @@ module.exports = {
                     };
 
                     if (input["Associated_person"][p]["association.person.association"] && input["Associated_person"][p]["association.person.association"][0]) {
-                        const _roleLabel = input["Associated_person"][p]["association.person.association"];
+                        const _roleLabel = input["Associated_person"][p]["association.person.association"][0];
                         const _roleURI = await adlib.getURIFromPriref("thesaurus", input["Associated_person"][p]["association.person.association.lref"][0], "concept");
                         person["@reverse"] = {
                             "Rol.agent": {


### PR DESCRIPTION
const _roleLabel = input["Associated_person"][p]["association.person.association"];

_roleLabel is an array, see https://github.com/StadGent/node_service_adlib-backend/commit/8da45dd38dbaa699197b39018aec0fb3b4e37ae7#diff-db69b4c952cabaec5abf9109d66ce085d18142479707f685b4e3d079bf578091R809

This results in:
```
ldes-archief_1 | [2022-03-08T16:06:09.033Z] INFO: 200 https://apidg.gent.be/opendata/adlib2eventstream/v1/archiefgent/objecten?generatedAtTime=2022-03-03T00:01:30.482Z (494) ms
ldes-archief_1 | events.js:377
ldes-archief_1 | throw er; // Unhandled 'error' event
ldes-archief_1 | ^
ldes-archief_1 |
ldes-archief_1 | ErrorCoded: The value of an '@value' can not be an object, got '["bouwheer"]'
```

Due to the label being an array:
```
"skos:prefLabel": {
  "@value": [
    "bouwheer"
  ],
  "@language": "nl"
}
```