### PR TITLE
Fix TypeError: Cannot read properties of undefined (reading 'push')

### DIFF
--- a/src/lib/mappers/tentoonstellingMapper.js
+++ b/src/lib/mappers/tentoonstellingMapper.js
@@ -110,16 +110,15 @@ export default class TentoonstellingMapper extends Transform {
             };
             mappedObject["Object.identificator"].push(prirefIdentificator);
 
-            // tentoonstellingstitel
+            // tentoonstellings titel.
             if (input['title'] && input['title'][0]) {
-                const _title = [{
+                mappedObject["cidoc:P1_is_identified_by"] = {
                     "@type": "cidoc:E33_E41_Linguistic_Appellation",
                     "inhoud": {
                         "@value": input['title'][0],
                         "@language": "nl"
                     }
-                }]
-                mappedObject["cidoc:P1_is_identified_by"].push(_title);
+                };
             };
 
             // todo: alternatieve titel.


### PR DESCRIPTION
```
TypeError: Cannot read properties of undefined (reading 'push')    at TentoonstellingMapper.doMapping (/Volumes/webdev/www/district09/coghent/StadGent/node_service_adlib-backend/src/lib/mappers/tentoonstellingMapper.js:122:59)    at TentoonstellingMapper._transform (/Volumes/webdev/www/district09/coghent/StadGent/node_service_adlib-backend/src/lib/mappers/tentoonstellingMapper.js:54:14)    at TentoonstellingMapper.Transform._write (node:internal/streams/transform:184:23)    at writeOrBuffer (node:internal/streams/writable:389:12)    at _write (node:internal/streams/writable:330:10)    at TentoonstellingMapper.Writable.write (node:internal/streams/writable:334:10)    at Adlib.ondata (node:internal/streams/readable:754:22)    at Adlib.emit (node:events:527:28)    at Adlib.emit (node:domain:475:12)    at addChunk (node:internal/streams/readable:315:12)    at readableAddChunk (node:internal/streams/readable:289:9)    at Adlib.push (node:internal/streams/readable:228:10)    at Adlib.fetchWithNTLMRecursively (/Volumes/webdev/www/district09/coghent/StadGent/node_service_adlib-backend/src/lib/adlib.js:156:22)    at Adlib.run (/Volumes/webdev/www/district09/coghent/StadGent/node_service_adlib-backend/src/lib/adlib.js:112:5)
```