### PR TITLE
Fix missing organiser on exposition

### DIFF
--- a/src/lib/mappers/tentoonstellingMapper.js
+++ b/src/lib/mappers/tentoonstellingMapper.js
@@ -146,7 +146,7 @@ export default class TentoonstellingMapper extends Transform {
             }
 
             // organisator van de tentoonstelling
-            if (input.organiser[0]["organiser"] && input.organiser[0]["organiser.lref"]) {
+            if (input.organiser && input.organiser[0]["organiser"] && input.organiser[0]["organiser.lref"]) {
                 const placeURI = await this._adlib.getURIFromPriref("personen", input.organiser[0]["organiser.lref"][0], "concept");
                 const placeLabel = input.organiser[0]["organiser"][0];
                 mappedObject["uitgevoerdDoor"] = {


### PR DESCRIPTION
This exposition has no organiser: https://cjm-web.adlibhosting.com/coghentapi/wwwopac.ashx?output=json&database=tentoonstellingen&search=priref=530000264&limit=1

This results in:

```
TypeError: Cannot read properties of undefined (reading '0')
    at TentoonstellingMapper.doMapping (/Volumes/webdev/www/district09/coghent/StadGent/node_service_adlib-backend/src/lib/mappers/tentoonstellingMapper.js:149:32)
    at TentoonstellingMapper._transform (/Volumes/webdev/www/district09/coghent/StadGent/node_service_adlib-backend/src/lib/mappers/tentoonstellingMapper.js:54:14)
    at TentoonstellingMapper.Transform._write (node:internal/streams/transform:184:23)
    at writeOrBuffer (node:internal/streams/writable:389:12)
    at _write (node:internal/streams/writable:330:10)
    at TentoonstellingMapper.Writable.write (node:internal/streams/writable:334:10)
    at Adlib.ondata (node:internal/streams/readable:754:22)
    at Adlib.emit (node:events:527:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Adlib.push (node:internal/streams/readable:228:10)
    at Adlib.fetchWithNTLMRecursively (/Volumes/webdev/www/district09/coghent/StadGent/node_service_adlib-backend/src/lib/adlib.js:156:22)
    at Adlib.run (/Volumes/webdev/www/district09/coghent/StadGent/node_service_adlib-backend/src/lib/adlib.js:112:5)
Error mapping priref 530000264
{"@timestamp":"2023-02-13T07:47:00.295Z","@version":"1.1.0","message":"Processed 5 / 524 for institution dmg from database tentoonstellingen","log":{"level":"INFO","logger":"adlib-backend/lib/adlib.js:fetchWithNTLMRecursively"},"d09":{"correlationId":"c6a7e7d9-5716-4ce8-a352-6a85cbc79b91","subcel":"web"},"memory":{"total":"43.45MB","used":"39.35MB","buffer":"0.07MB"}}
```