### PR TITLE
Fix last record

### DIFF
--- a/src/lib/adlib.js
+++ b/src/lib/adlib.js
@@ -55,8 +55,10 @@ Adlib.prototype.updateLastRecordWithDone = async function () {
             version: process.env.npm_package_version ? process.env.npm_package_version : '0.0.0'
         }
     });
-    lastObject.done = true;
-    await lastObject.save();
+    if (lastObject) {
+        lastObject.done = true;
+        await lastObject.save();
+    }
 }
 Adlib.prototype.run = async function () {
     const version = process.env.npm_package_version ? process.env.npm_package_version : '0.0.0';


### PR DESCRIPTION
  lastObject.done = true;
                  ^

TypeError: Cannot set properties of null (setting 'done')
    at Adlib.updateLastRecordWithDone (/workspaces/node_service_adlib-backend/src/lib/adlib.js:58:20)
    at Adlib.<anonymous> (/workspaces/node_service_adlib-backend/src/app.js:278:9)