### PR TITLE
Update date type to EDTF in acquisition date mapping

### DIFF
--- a/src/lib/mappers/utils.js
+++ b/src/lib/mappers/utils.js
@@ -720,10 +720,10 @@ module.exports = {
         if (input["acquisition.date"]) {
             const datum = input["acquisition.date"][0];
             v["Gebeurtenis.tijd"] = {
-                "@type": "Periode",
+                // change from "Periode" to EDTF, because "Periode" refers to dateTime, here EDTF is used.
+                "@type": "http://id.loc.gov/datatypes/edtf/EDTF",
                 "Periode.begin": datum,
                 "Periode.einde": datum
-                //todo
             };
         }
 


### PR DESCRIPTION
Changed "@type" from "Periode" to EDTF in the mapping logic to accurately reflect the expected data type. This ensures compatibility with the EDTF standard for representing date information.